### PR TITLE
source the env variables at run the CMD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 if [ ${VAULT_TOKEN+x} ]
 then
   consul-template -consul=$CONSUL_ADDR -template=/exports.ctmpl:/tmp/exports.sh -once
-  source /tmp/exports.sh
+  exec "source /tmp/exports.sh && $*"
 else
   echo "VAULT_TOKEN is not set skipping exports"
+  exec "$@"
 fi
-exec "$@"


### PR DESCRIPTION
 - the env variables are not getting passed to the exec command (I think) so run the source and the CMD in the same line