### PR TITLE
put the exec back the way it was.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 if [ ${VAULT_TOKEN+x} ]
 then
   consul-template -consul=$CONSUL_ADDR -template=/exports.ctmpl:/tmp/exports.sh -once
-  exec "source /tmp/exports.sh && $*"
+  source /tmp/exports.sh
 else
   echo "VAULT_TOKEN is not set skipping exports"
-  exec "$@"
 fi
+exec "$@"


### PR DESCRIPTION
testing it locally seems to work the old way. 