### PR TITLE
fix the token check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ${VAULT_TOKEN+x} ]
+if [ ${VAULT_TOKEN} ]
 then
   consul-template -consul=$CONSUL_ADDR -template=/exports.ctmpl:/tmp/exports.sh -once
   source /tmp/exports.sh


### PR DESCRIPTION
 - +x replaces an empty string with x if the variable exists but is empty. we do not want this to execute if the variable is empty.