### PR TITLE
read global environment variables

### DIFF
--- a/exports.ctmpl
+++ b/exports.ctmpl
@@ -1,6 +1,10 @@
 #!/bin/bash
 {{$env := env "APP_ENV" }}
 {{$appname := env "APP_NAME" }}
+#global envs
+{{range ls "apps/global/envs"}}
+export {{.Key | toUpper}}="{{.Value}}"{{end}}
+#app envs
 {{range ls (printf "apps/%s/%s" $appname $env )}}
 export {{.Key | toUpper}}="{{.Value}}"{{end}}
 {{range secrets (printf "secret/apps/%s/%s" $appname $env) }}export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/%s" $appname $env .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}

--- a/exports.ctmpl
+++ b/exports.ctmpl
@@ -2,7 +2,7 @@
 {{$env := env "APP_ENV" }}
 {{$appname := env "APP_NAME" }}
 #global envs
-{{range ls "apps/global/envs"}}
+{{range ls (printf "apps/global/%s" $env )}}
 export {{.Key | toUpper}}="{{.Value}}"{{end}}
 #app envs
 {{range ls (printf "apps/%s/%s" $appname $env )}}


### PR DESCRIPTION
 - many things like new relic license key, aws_region and others apply to many apps. include a place to store those so we can write them out in terraform once (instead of once for each consuming app)
 - read in those global env variables

@tecnobrat @articulate/web-ops 

this goes along with a PR I am building for 360-content-pass (and will apply to others as we transition to consul and vault)