### PR TITLE
Don't proceed on an error and show a message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 if [ ${VAULT_TOKEN} ]
 then
-  consul-template -consul=$CONSUL_ADDR -template=/exports.ctmpl:/tmp/exports.sh -once
-  source /tmp/exports.sh
+  if consul-template -consul=$CONSUL_ADDR -template=/exports.ctmpl:/tmp/exports.sh -once
+  then
+    source /tmp/exports.sh
+  else
+    echo "======== CONSUL OR VAULT ARE HAVING ISSUES, WEB OPS HAVE BEEN ALERTED ========"
+    exit 1
+  fi
 else
   echo "VAULT_TOKEN is not set skipping exports"
 fi


### PR DESCRIPTION
This way we don't have apps in a broken state, also spewing application startup failures to the logs.  But we still log something nice in logstash.