### PR TITLE
add the wget apt-get package to install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y unzip git sudo python-dev jq
+apt-get install -y unzip git sudo python-dev jq wget
 rm -rf /var/lib/apt/lists/*
 
 git clone https://github.com/articulate/docker-consul-template-bootstrap.git


### PR DESCRIPTION
adding the wget apt-get package to the install.sh script because I'm getting some errors when trying to use this with my datadog-tracer-agent image.  getting the following error there during the build of that image using this install.sh script:

```
Cloning into 'docker-consul-template-bootstrap'...
/tmp/consul_template_install.sh: line 8: wget: command not found
unzip:  cannot find or open consul-template_0.18.0-rc1_linux_amd64.zip, consul-template_0.18.0-rc1_linux_amd64.zip.zip or consul-template_0.18.0-rc1_linux_amd64.zip.ZIP.
/tmp/consul_template_install.sh: line 11: wget: command not found
unzip:  cannot find or open awscli-bundle.zip, awscli-bundle.zip.zip or awscli-bundle.zip.ZIP.
sudo: ./awscli-bundle/install: command not found
```