### PR TITLE
update consul templates to skip env vars set in peer already

### DIFF
--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -1,15 +1,19 @@
 #!/bin/bash -e
 {{scratch.Set "env" (env "APP_ENV") -}}
-{{$appname := env "APP_NAME" -}}
-{{if scratch.Get "env" | contains "peer"}}{{scratch.Set "env" "stage"}}{{end -}}
-
-{{$env := scratch.Get "env"}}
+{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "peer" true)}}{{end -}}
 
 #global envs
-{{range ls (printf "global/%s/env_vars" $env ) -}}
-export {{.Key | toUpper}}="{{.Value}}"
+{{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
+{{if and (scratch.Get "peer") (not (env .Key))}}export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
+{{if not (scratch.Get "peer")}}export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
+{{end -}}
+
 #app envs
-{{range ls (printf "apps/%s/%s/env_vars" $appname $env ) -}}
-export {{.Key | toUpper}}="{{.Value}}"
+{{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{if and (scratch.Get "peer") (not (env .Key))}}export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
+{{if not (scratch.Get "peer")}}export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}

--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -4,16 +4,20 @@
 
 #global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
-{{if and (scratch.Get "peer") (not (env .Key))}}export {{.Key | toUpper}}="{{.Value}}"
+{{if and (scratch.Get "peer") (not (env .Key)) -}}
+export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
-{{if not (scratch.Get "peer")}}export {{.Key | toUpper}}="{{.Value}}"
+{{if not (scratch.Get "peer") -}}
+export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
 #app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
-{{if and (scratch.Get "peer") (not (env .Key))}}export {{.Key | toUpper}}="{{.Value}}"
+{{if and (scratch.Get "peer") (not (env .Key)) -}}
+export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
-{{if not (scratch.Get "peer")}}export {{.Key | toUpper}}="{{.Value}}"
+{{if not (scratch.Get "peer") -}}
+export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}

--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -4,6 +4,7 @@
 
 #global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if and (scratch.Get "peer") (not (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
@@ -14,6 +15,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 
 #app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if and (scratch.Get "peer") (not (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -1,15 +1,19 @@
 #!/bin/bash -e
 {{scratch.Set "env" (env "APP_ENV") -}}
-{{$appname := env "APP_NAME" -}}
-{{if scratch.Get "env" | contains "peer"}}{{scratch.Set "env" "stage"}}{{end -}}
-
-{{$env := scratch.Get "env"}}
+{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "peer" true)}}{{end -}}
 
 #global secrets
-{{range secrets (printf "secret/global/%s/env_vars" $env ) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" $env .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
+{{if and (scratch.Get "peer") (not (env .))}}export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
 {{end -}}
+{{if not (scratch.Get "peer")}}export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{end -}}
+{{end -}}
+
 #app secrets
-{{range secrets (printf "secret/apps/%s/%s/env_vars" $appname $env) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" $appname $env .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{if and (scratch.Get "peer") (not (env .))}}export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{end -}}
+{{if not (scratch.Get "peer")}}export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -4,16 +4,20 @@
 
 #global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
-{{if and (scratch.Get "peer") (not (env .))}}export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{if and (scratch.Get "peer") (not (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
 {{end -}}
-{{if not (scratch.Get "peer")}}export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{if not (scratch.Get "peer") -}}
+export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
 {{end -}}
 {{end -}}
 
 #app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
-{{if and (scratch.Get "peer") (not (env .))}}export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{if and (scratch.Get "peer") (not (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
 {{end -}}
-{{if not (scratch.Get "peer")}}export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+{{if not (scratch.Get "peer") -}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
 {{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -4,6 +4,7 @@
 
 #global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if and (scratch.Get "peer") (not (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
@@ -14,6 +15,7 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scr
 
 #app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if and (scratch.Get "peer") (not (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -5,19 +5,19 @@
 #global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
 {{if and (scratch.Get "peer") (not (env .)) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{if not (scratch.Get "peer") -}}
-export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
 #app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{if and (scratch.Get "peer") (not (env .)) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{if not (scratch.Get "peer") -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}{{range $k, $v := .Data}}="{{$v}}"{{end}}{{end}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}


### PR DESCRIPTION
Updating the consul-templates for the consul and vault environment variable setting to ignore setting environment variables that are already set via the ECS peer cluster if `APP_ENV` = peer.  This works via the `{{if and (scratch.Get "peer") (not (env .Key))}}` lines in the export-consul.ctmpl template and the `{{if and (scratch.Get "peer") (not (env .))}}` lines in the export-vault.ctmpl template.  They are both checking to see if the environment is peer and if the environment variable exists there.  I've tested this a bunch of times over already via an instance in the dev-zone that has access to consul and vault stage and it works great.