### PR TITLE
override consul and vault env vars for dev APP_ENV

### DIFF
--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 {{scratch.Set "env" (env "APP_ENV") -}}
-{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "peer" true)}}{{end -}}
+{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
+{{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
 #global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "peer") (not (env .Key)) -}}
+{{if and (scratch.Get "override") (not (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
-{{if not (scratch.Get "peer") -}}
+{{if not (scratch.Get "override") -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -16,10 +17,10 @@ export {{.Key | toUpper}}="{{.Value}}"
 #app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "peer") (not (env .Key)) -}}
+{{if and (scratch.Get "override") (not (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
-{{if not (scratch.Get "peer") -}}
+{{if not (scratch.Get "override") -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 {{scratch.Set "env" (env "APP_ENV") -}}
-{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "peer" true)}}{{end -}}
+{{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
+{{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
 #global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "peer") (not (env .)) -}}
+{{if and (scratch.Get "override") (not (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
-{{if not (scratch.Get "peer") -}}
+{{if not (scratch.Get "override") -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
@@ -16,10 +17,10 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scr
 #app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "peer") (not (env .)) -}}
+{{if and (scratch.Get "override") (not (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
-{{if not (scratch.Get "peer") -}}
+{{if not (scratch.Get "override") -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}


### PR DESCRIPTION
similar to environment variables passed to the peer containers via `service.json` this will allow for local dev environment variables to be set via the docker-compose.yml that will override the consul/vault values from the `/dev` namespaces there.  this will make local tinkering with dev environments more flexible to one off changes/experimentation.