### PR TITLE
Add products namespace to consul/vault

### DIFF
--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -40,7 +40,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 
 #app envs
-{{range ls (printf "apps/%s/env_vars" (env "APP_NAME")) -}}
+{{range ls (printf "services/%s/env_vars" (env "APP_NAME")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"

--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -3,13 +3,11 @@
 {{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
 {{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
+## OLD DEPRECATED STYLE
 #global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "override") (not (env .Key)) -}}
-export {{.Key | toUpper}}="{{.Value}}"
-{{end -}}
-{{if not (scratch.Get "override") -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -17,10 +15,32 @@ export {{.Key | toUpper}}="{{.Value}}"
 #app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "override") (not (env .Key)) -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
-{{if not (scratch.Get "override") -}}
+{{end -}}
+
+## NEW STYLE
+#global envs
+{{range ls "global/env_vars" -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
+{{end -}}
+
+#products envs
+{{range ls (printf "products/%s/env_vars" (env "APP_PRODUCT")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
+{{end -}}
+
+#app envs
+{{range ls (printf "apps/%s/env_vars" (env "APP_NAME")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}

--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -30,10 +30,12 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 
 #products envs
+{{if (env "APP_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "APP_PRODUCT")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}
 {{end -}}
 

--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -7,7 +7,7 @@
 #global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -15,7 +15,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 #app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -24,7 +24,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 #global envs
 {{range ls "global/env_vars" -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -32,7 +32,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 #products envs
 {{range ls (printf "products/%s/env_vars" (env "APP_PRODUCT")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
@@ -40,7 +40,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 #app envs
 {{range ls (printf "apps/%s/env_vars" (env "APP_NAME")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -40,9 +40,9 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 
 #app secrets
-{{range secrets (printf "secret/apps/%s/env_vars" (env "APP_NAME")) -}}
+{{range secrets (printf "secret/services/%s/env_vars" (env "APP_NAME")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .)) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/env_vars/%s" (env "APP_NAME") .) }}="{{.Data.value}}"{{end}}
+export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "APP_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -3,13 +3,11 @@
 {{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
 {{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
+## OLD DEPRECATED STYLE
 #global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "override") (not (env .)) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
-{{end -}}
-{{if not (scratch.Get "override") -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
@@ -17,10 +15,34 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scr
 #app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if and (scratch.Get "override") (not (env .)) -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
-{{if not (scratch.Get "override") -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
+
+## NEW STYLE
+#global secrets
+{{range secrets (printf "secret/global/env_vars" (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+{{if (not (env "APP_PRODUCT")) -}}
+#products secrets
+{{range secrets (printf "secret/products/%s/env_vars" (env "APP_PRODUCT")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (env "APP_PRODUCT") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
+{{end -}}
+{{end -}}
+
+#app secrets
+{{range secrets (printf "secret/apps/%s/env_vars" (env "APP_NAME")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/env_vars/%s" (env "APP_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -29,8 +29,8 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="
 {{end -}}
 {{end -}}
 
-{{if (env "APP_PRODUCT") -}}
 #products secrets
+{{if (env "APP_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "APP_PRODUCT")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .)) -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -29,7 +29,7 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="
 {{end -}}
 {{end -}}
 
-{{if (not (env "APP_PRODUCT")) -}}
+{{if (env "APP_PRODUCT") -}}
 #products secrets
 {{range secrets (printf "secret/products/%s/env_vars" (env "APP_PRODUCT")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}


### PR DESCRIPTION
We are going to start reading environment variables from the namespace `products/${product_name}/env_vars` namespace.

This also adds support for dropping the environment name inside the consul / vault paths.

And thanks to @defn we have a much better conditional to detect if we should be exporting variables.