### PR TITLE
rearrange env var order in consul and vault templates

### DIFF
--- a/export-consul.ctmpl
+++ b/export-consul.ctmpl
@@ -3,8 +3,7 @@
 {{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
 {{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
-## OLD DEPRECATED STYLE
-#global envs
+## OLD STYLE global envs
 {{range ls (printf "global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .Key)) -}}
@@ -12,16 +11,7 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#app envs
-{{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
-{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .Key)) -}}
-export {{.Key | toUpper}}="{{.Value}}"
-{{end -}}
-{{end -}}
-
-## NEW STYLE
-#global envs
+## NEW STYLE global envs
 {{range ls "global/env_vars" -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .Key)) -}}
@@ -39,7 +29,15 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#app envs
+#OLD STYLE app envs
+{{range ls (printf "apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .Key)) -}}
+export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
+{{end -}}
+
+#NEW STYLE app envs
 {{range ls (printf "services/%s/env_vars" (env "APP_NAME")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .Key)) -}}

--- a/export-vault.ctmpl
+++ b/export-vault.ctmpl
@@ -3,8 +3,7 @@
 {{if scratch.Get "env" | contains "peer"}}{{and (scratch.Set "env" "stage") (scratch.Set "override" true)}}{{end -}}
 {{if scratch.Get "env" | contains "dev"}}{{(scratch.Set "override" true)}}{{end -}}
 
-## OLD DEPRECATED STYLE
-#global secrets
+## OLD DEPRECATED STYLE global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (scratch.Get "env")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .)) -}}
@@ -12,26 +11,18 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (scr
 {{end -}}
 {{end -}}
 
-#app secrets
-{{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
-{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
-{{if not (and (scratch.Get "override") (env .)) -}}
-export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
-{{end -}}
-{{end -}}
-
-## NEW STYLE
+#NEW STYLE global secrets
 {{if not (scratch.Get "env" | contains "dev") -}}
-
-#global secrets
 {{range secrets "secret/global/env_vars" -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
+{{end -}}
 
 #products secrets
+{{if not (scratch.Get "env" | contains "dev") -}}
 {{if (env "APP_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "APP_PRODUCT")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
@@ -40,13 +31,22 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 {{end -}}
 {{end -}}
+{{end -}}
 
-#app secrets
+#OLD DEPRECATED STYLE app secrets
+{{range secrets (printf "secret/apps/%s/%s/env_vars" (env "APP_NAME") (scratch.Get "env")) -}}
+{{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
+{{if not (and (scratch.Get "override") (env .)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "APP_NAME") (scratch.Get "env") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#NEW STYLE app secrets
+{{if not (scratch.Get "env" | contains "dev") -}}
 {{range secrets (printf "secret/services/%s/env_vars" (env "APP_NAME")) -}}
 {{/* check to see if app is peer related and skip ENV VARS that are already set */ -}}
 {{if not (and (scratch.Get "override") (env .)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "APP_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
-
 {{end -}}


### PR DESCRIPTION
rearranging env var order in consul and vault templates so that the order of precedence on sourcing them is:

1. App Level Env Vars (New Style trumps Old Style)
2. Product Level Env Vars
3. Global Level Env Vars (New Style trumps Old Style)