### PR TITLE
remove Scratch.get from peer/export-vault.ctmpl

### DIFF
--- a/peer/export-vault.ctmpl
+++ b/peer/export-vault.ctmpl
@@ -24,7 +24,7 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 
 #OLD DEPRECATED STYLE app secrets
-{{range secrets (printf "secret/apps/%s/stage/env_vars" (env "SERVICE_NAME") (scratch.Get "env")) -}}
+{{range secrets (printf "secret/apps/%s/stage/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/stage/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}


### PR DESCRIPTION
pretty sure that this extra `(scratch.Get "env")` is messing with how the old app style secrets are being pulled from vault for peer - we're seeing global level vault env vars making it to containers but not older app level ones and I think this is why