### PR TITLE
Add test for old vars, which should fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ environment:
 
 You can run vault locally with `vault server -dev`. This command will output the VAULT_TOKEN you need and listen on port 8200. I use [localtunnel](https://localtunnel.me) to grab a url to use as the VAULT_ADDR.
 `lt --port 8200 -s myarticulatetest`
+
+## Test Suite
+
+To run the test suite, first make sure your changes are commited and
+pushed to github.  Then run:
+
+`docker-compose run app`
+
+If your changes are not commited and pushed it will not be picked up
+when the test images build.

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -141,13 +141,17 @@ distros.each do |distro|
         [:consul, :vault].each do |backend_type|
           describe backend_type do
             describe "General sets work" do
+              set_var(backend_type, :global, "OLD_GLOBAL_VAR", "old-global-var", old_keys: true)
               set_var(backend_type, :global, "GLOBAL_VAR", "global-var")
               set_var(backend_type, :product, "PRODUCT_VAR", "product-var")
+              set_var(backend_type, :service, "OLD_SERVICE_VAR", "old-service-var", old_keys: true)
               set_var(backend_type, :service, "SERVICE_VAR", "service-var")
 
               describe entrypoint_command("env") do
+                its(:stdout) { should include_env "OLD_GLOBAL_VAR", "old-global-var" }
                 its(:stdout) { should include_env "GLOBAL_VAR", "global-var" }
                 its(:stdout) { should include_env "PRODUCT_VAR", "product-var" }
+                its(:stdout) { should include_env "OLD_SERVICE_VAR", "old-service-var" }
                 its(:stdout) { should include_env "SERVICE_VAR", "service-var" }
                 its(:stdout) { should include_env "SERVICE_ENV", "peer-rise-runtime-1768" }
                 its(:stderr) { should be_empty }


### PR DESCRIPTION
These tests should fail on the "head" branch, but pass on the "merge"