### PR TITLE
add support to consul templates for v2 of the vault k/v store

### DIFF
--- a/dev/export-vault.ctmpl
+++ b/dev/export-vault.ctmpl
@@ -13,3 +13,23 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
+
+######################################################
+##                                                  ##
+## Add Support for New Vault (0.10.0) Versioned K/V ##
+##                                                  ##
+######################################################
+
+## OLD DEPRECATED STYLE global secrets
+{{range secrets (printf "secret/metadata/global/%s/env_vars" (env "SERVICE_ENV")) -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#OLD DEPRECATED STYLE app secrets
+{{range secrets (printf "secret/metadata/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}

--- a/peer/export-vault.ctmpl
+++ b/peer/export-vault.ctmpl
@@ -36,3 +36,46 @@ export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/stage/env_vars/%s" 
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
+
+######################################################
+##                                                  ##
+## Add Support for New Vault (0.10.0) Versioned K/V ##
+##                                                  ##
+######################################################
+
+## OLD DEPRECATED STYLE global secrets
+{{range secrets "secret/metadata/global/stage/env_vars" -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/global/stage/env_vars/%s" .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#NEW STYLE global secrets
+{{range secrets "secret/metadata/global/env_vars" -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/global/env_vars/%s" .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#products secrets
+{{if (env "SERVICE_PRODUCT") -}}
+{{range secrets (printf "secret/metadata/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/products/%s/env_vars/%s" (env "SERVICE_PRODUCT") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+{{end -}}
+
+#OLD DEPRECATED STYLE app secrets
+{{range secrets (printf "secret/metadata/apps/%s/stage/env_vars" (env "SERVICE_NAME")) -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/apps/%s/stage/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#NEW STYLE app secrets
+{{range secrets (printf "secret/metadata/services/%s/env_vars" (env "SERVICE_NAME")) -}}
+{{if not (env (. | toUpper)) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}

--- a/prod/export-vault.ctmpl
+++ b/prod/export-vault.ctmpl
@@ -26,3 +26,36 @@ export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (en
 {{range secrets (printf "secret/services/%s/env_vars" (env "SERVICE_NAME")) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
+
+######################################################
+##                                                  ##
+## Add Support for New Vault (0.10.0) Versioned K/V ##
+##                                                  ##
+######################################################
+
+## OLD DEPRECATED STYLE global secrets
+{{range secrets (printf "secret/metadata/global/%s/env_vars" (env "SERVICE_ENV")) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+
+#NEW STYLE global secrets
+{{range secrets "secret/metadata/global/env_vars" -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/global/env_vars/%s" .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+
+#products secrets
+{{if (env "SERVICE_PRODUCT") -}}
+{{range secrets (printf "secret/metadata/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/products/%s/env_vars/%s" (env "SERVICE_PRODUCT") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
+#OLD DEPRECATED STYLE app secrets
+{{range secrets (printf "secret/metadata/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}
+
+#NEW STYLE app secrets
+{{range secrets (printf "secret/metadata/services/%s/env_vars" (env "SERVICE_NAME")) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/data/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.data.value}}"{{end}}
+{{end -}}


### PR DESCRIPTION
the paths to the secrets in vault change when the move to v2 of the vault k/v store is made since each k/v now contains a `data` and `metadata` portion; this PR will allow us to use the newer v2 of the k/v store and v1 at the same time so we should be able to cutover to v2 easily without downtime.