### PR TITLE
delay sourcing of consul and vault export scripts if env isn't dev

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [ ${CONSUL_ADDR} ]
 then
   if consul-template -consul-addr=$CONSUL_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-consul.ctmpl:/tmp/export-consul.sh -once -max-stale=0
   then
-    source /tmp/export-consul.sh
+    if [ "$CT_SERVICE_ENV" == "dev" ]; then source /tmp/export-consul.sh; fi
   else
     (>&2 echo "Consul $MISBEHAVING_NOTICE")
     exit 1
@@ -42,13 +42,18 @@ if [ ${VAULT_TOKEN} ] && [ ${CONSUL_ADDR} ] && [ ${VAULT_ADDR} ]
 then
   if consul-template -consul-addr=$CONSUL_ADDR -vault-addr=$VAULT_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-vault.ctmpl:/tmp/export-vault.sh -once -max-stale=0
   then
-    source /tmp/export-vault.sh
+    if [ "$CT_SERVICE_ENV" == "dev" ]; then source /tmp/export-vault.sh; fi
   else
     (>&2 echo "Vault $MISBEHAVING_NOTICE")
     exit 1
   fi
 else
   (>&2 echo "VAULT_TOKEN or VAULT_ADDR are not set, skipping Vault exports")
+fi
+
+if [ "$CT_SERVICE_ENV" != "dev" ]; then
+  source /tmp/export-consul.sh;
+  source /tmp/export-vault.sh;
 fi
 
 rm -f /tmp/export-vault.sh


### PR DESCRIPTION
A recent change to the way the consul and vault templates handled env vars that were set outside of consul and vault, https://github.com/articulate/docker-consul-template-bootstrap/pull/53, caused an issue where consul env vars would override vault env vars with the same name.  This is due to the fact that the consul export script gets sourced immediately after it's created from the template, making those env vars get skipped in the vault template if they are set from outside sources or consul in this case.  We want the vault env vars to take precedence over the consul ones.

We do however have an issue where the `dev` consul script needs to get run before the vault template gets generated so the shared [ENCRYPTED_VAULT_TOKEN](https://consul.articulate.zone/ui/dc1/kv/global/dev/env_vars/ENCRYPTED_VAULT_TOKEN/edit) can be pulled from consul.  This means we want to keep the behavior the same for the order of sourcing those env vars in `dev` but in other cases delay that sourcing until both templates are generated.