### PR TITLE
Get vault token from k8s auth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    aws-sigv4 (1.0.3)
     capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -33,7 +34,7 @@ GEM
       specinfra-backend-docker_lxc (~> 0.2.0)
     erubis (2.7.0)
     excon (0.60.0)
-    faraday (0.13.1)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
@@ -103,7 +104,8 @@ GEM
     specinfra-backend-docker_lxc (0.2.0)
       specinfra (~> 2.13)
     thor (0.20.0)
-    vault (0.10.1)
+    vault (0.12.0)
+      aws-sigv4
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -120,4 +122,4 @@ DEPENDENCIES
   vault
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,13 @@ services:
       - vault
 
   consul:
-    image: consul
+    image: consul:latest
     command: "agent -dev -log-level info -client 0.0.0.0"
 
   vault:
-    image: vault
+    image: vault:latest
+    command: server -dev-kv-v1 -dev
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "vault-token"
+    cap_add:
+      - IPC_LOCK

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,11 +33,12 @@ else
   (>&2 echo "CONSUL_ADDR are not set skipping Consul exports")
 fi
 
-if [ ! "${VAULT_TOKEN}" ] && [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
+then
   KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-  VAULT_TOKEN=$(curl --request POST \
+  export VAULT_TOKEN=$(curl --request POST \
     --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "'"$SERVICE_NAME"'"}' \
-    $VAULT_ADDR/v1/auth/kubernetes/login | jq '.auth.client_token')
+    $VAULT_ADDR/v1/auth/kubernetes/login | jq -r '.auth.client_token')
 fi
 
 if [ "${ENCRYPTED_VAULT_TOKEN}" ] && [ ! "${VAULT_TOKEN}" ]

--- a/install.sh
+++ b/install.sh
@@ -7,14 +7,14 @@ fi
 
 if [ `command -v apt-get` ]; then
   apt-get update
-  apt-get install -y unzip sudo python-dev jq wget
+  apt-get install -y unzip sudo python-dev jq wget curl
   rm -rf /var/lib/apt/lists/*
 elif [ `command -v yum` ]; then
   yum -y update
-  yum -y install unzip sudo python-devel jq wget
+  yum -y install unzip sudo python-devel jq wget curl
   yum clean all
 elif [ `command -v apk` ]; then
-  apk --update add unzip sudo python-dev jq wget ca-certificates
+  apk --update add unzip sudo python-dev jq wget ca-certificates curl
   update-ca-certificates
   rm -rf /var/cache/apk/*
 else


### PR DESCRIPTION
This allows us to not require vault tokens at all for k8s services. Instead, we get the vault token via vault + k8s's auth integration.