### PR TITLE
add products vault env vars to dev consul-template

### DIFF
--- a/dev/export-vault.ctmpl
+++ b/dev/export-vault.ctmpl
@@ -7,6 +7,13 @@ export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env
 {{end -}}
 {{end -}}
 
+#products secrets
+{{if (env "SERVICE_PRODUCT") -}}
+{{range secrets (printf "secret/products/%s/dev/env_vars" (env "SERVICE_PRODUCT")) -}}
+export {{ . | toUpper}}{{with secret (printf "secret/products/%s/dev/env_vars/%s" (env "SERVICE_PRODUCT") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
+{{end -}}
+
 #OLD DEPRECATED STYLE app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}


### PR DESCRIPTION
adding the `SERVICE_PRODUCTS` level vault env vars to the dev export-vault consul-template so local dev can get access to some env vars in the products/dev vault namespace; the vault policy to all the dev policy to this namespace has been added already as well - https://github.com/articulate/vault-policies/pull/104