### PR TITLE
skip all vault bootstrap steps if VAULT_ADDR isnt set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,51 +33,55 @@ else
   (>&2 echo "CONSUL_ADDR are not set skipping Consul exports")
 fi
 
-if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
-then
-  KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-  vault_token="null"
-  attempts=1
-  while [ "${attempts}" -le 10 ]; do
-    vault_token=$(curl -s --show-error --request POST \
-      --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "'"$SERVICE_NAME"'"}' \
-      $VAULT_ADDR/v1/auth/kubernetes/login | jq -r '.auth.client_token');
-    if [[ "${vault_token}" != "null" ]]; then
-       break
-    fi
-    echo "Attempt number ${attempts} to get vault token failed, retrying..."
-    ((attempts+=1))
-    sleep 3
-  done
-
-  if [[ "${vault_token}" == "null" ]]; then
-    echo "Failed to get vault token via kubernetes"
-    exit 1
-  fi
-  export VAULT_TOKEN=${vault_token}
-fi
-
-if [ "${ENCRYPTED_VAULT_TOKEN}" ] && [ ! "${VAULT_TOKEN}" ]
-then
-  export VAULT_TOKEN=$(echo $ENCRYPTED_VAULT_TOKEN | base64 -d | aws kms decrypt --ciphertext-blob fileb:///dev/stdin --output text --query Plaintext --region $AWS_REGION | base64 -d)
-fi
-
-if [ ! "${VAULT_TOKEN}" ] && [ "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" ]
-then
-  export VAULT_TOKEN=$(vault login -method=aws -token-only)
-fi
-
-if [ ${VAULT_TOKEN} ] && [ ${CONSUL_ADDR} ] && [ ${VAULT_ADDR} ]
-then
-  if consul-template -consul-addr=$CONSUL_ADDR -vault-addr=$VAULT_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-vault.ctmpl:/tmp/export-vault.sh -once -max-stale=0
+if [ ${VAULT_ADDR} ]
+  if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
   then
-    source /tmp/export-vault.sh
+    KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    vault_token="null"
+    attempts=1
+    while [ "${attempts}" -le 10 ]; do
+      vault_token=$(curl -s --show-error --request POST \
+        --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "'"$SERVICE_NAME"'"}' \
+        $VAULT_ADDR/v1/auth/kubernetes/login | jq -r '.auth.client_token');
+      if [[ "${vault_token}" != "null" ]]; then
+        break
+      fi
+      echo "Attempt number ${attempts} to get vault token failed, retrying..."
+      ((attempts+=1))
+      sleep 3
+    done
+
+    if [[ "${vault_token}" == "null" ]]; then
+      echo "Failed to get vault token via kubernetes"
+      exit 1
+    fi
+    export VAULT_TOKEN=${vault_token}
+  fi
+
+  if [ "${ENCRYPTED_VAULT_TOKEN}" ] && [ ! "${VAULT_TOKEN}" ]
+  then
+    export VAULT_TOKEN=$(echo $ENCRYPTED_VAULT_TOKEN | base64 -d | aws kms decrypt --ciphertext-blob fileb:///dev/stdin --output text --query Plaintext --region $AWS_REGION | base64 -d)
+  fi
+
+  if [ ! "${VAULT_TOKEN}" ] && [ "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" ]
+  then
+    export VAULT_TOKEN=$(vault login -method=aws -token-only)
+  fi
+
+  if [ ${VAULT_TOKEN} ] && [ ${CONSUL_ADDR} ]
+  then
+    if consul-template -consul-addr=$CONSUL_ADDR -vault-addr=$VAULT_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-vault.ctmpl:/tmp/export-vault.sh -once -max-stale=0
+    then
+      source /tmp/export-vault.sh
+    else
+      (>&2 echo "Vault $MISBEHAVING_NOTICE")
+      exit 1
+    fi
   else
-    (>&2 echo "Vault $MISBEHAVING_NOTICE")
-    exit 1
+    (>&2 echo "VAULT_TOKEN or VAULT_ADDR are not set, skipping Vault exports")
   fi
 else
-  (>&2 echo "VAULT_TOKEN or VAULT_ADDR are not set, skipping Vault exports")
+    (>&2 echo "VAULT_ADDR is not set, skipping Vault exports")
 fi
 
 rm -f /tmp/export-vault.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ else
 fi
 
 if [ ${VAULT_ADDR} ]
+  then
   if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
   then
     KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -78,7 +79,7 @@ if [ ${VAULT_ADDR} ]
       exit 1
     fi
   else
-    (>&2 echo "VAULT_TOKEN or VAULT_ADDR are not set, skipping Vault exports")
+    (>&2 echo "VAULT_TOKEN and/or CONSUL_ADDR not set, skipping Vault exports")
   fi
 else
     (>&2 echo "VAULT_ADDR is not set, skipping Vault exports")


### PR DESCRIPTION
Getting some messages in an ECS Fargate Cron task that showed it was trying to authenticate to vault locally on port 8200 because it didn't pass in a `VAULT_TOKEN` env var and had the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` env var associated with it because it was using a task role.  I'm thinking we should only be trying to connect to vault when the `VAULT_ADDR` is set in all cases.  Skipping all the vault bootstrap steps if that `VAULT_ADDR` env var isn't set to begin with.