### PR TITLE
If a token is passed in, use that instead of querying kubernetes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 if [ ${VAULT_ADDR} ]
   then
-  if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
+  if [ ! "${VAULT_TOKEN}" ] && [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
   then
     KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     vault_token="null"


### PR DESCRIPTION
In some cases, using k8s, we need to hardcode a token.