### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ In order to test this locally you will need to edit the `docker-compose.override
 ```
 environment:
     SERVICE_NAME: "your-service"
-    SERVICE_ENV: "dev|stage|prod|peer"
-    CONSUL_ADDR: "http://consul.articulate.zone"
+    SERVICE_ENV: "dev|stage|prod|peer|apiary"
     VAULT_ADDR: "https://myarticulatetest.localtunnel.me"
     VAULT_TOKEN: "your-token"
 ```


### PR DESCRIPTION
I find the instructions on here overall a bit confusing to follow...but is there a reason why we wanted people to be pointing to the legacy-stage consul? I updated that address to the mgmt-stage consul and wound up wiping out the entire thing. I think if you just leave that line out it will default to your local consul just fine...