### PR TITLE
Add compatibility for amazon linux lambda images

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # Due to docker's layer caching, you may need to update this file in a way to force docker
 # to skip the layer cache and re-run this install the next time it builds the image.
-# Simply edit the date here: 2020-10-24
+# Simply edit the date here: 2020-10-26
 
 CONSUL_TEMPLATE_BOOTSTRAP_REF=$1
 if [ "${CONSUL_TEMPLATE_BOOTSTRAP_REF}" == "" ]; then
@@ -17,12 +17,12 @@ if [ `command -v apt-get` ]; then
   apt-get clean && apt-get autoclean && apt-get -y autoremove --purge
   rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/
 elif [ `command -v yum` ]; then
-  yum -y install epel-release
+  grep "Amazon Linux" /etc/os-release &>/dev/null || yum -y install epel-release
   yum -y update
   yum -y install unzip jq sudo wget curl which
   wget -q -O /tmp/awscli-bundle.zip "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
   unzip -d /tmp /tmp/awscli-bundle.zip
-  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+  /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
   rm -rf /tmp/awscli-bundle*
   yum clean all
 elif [ `command -v apk` ]; then
@@ -46,8 +46,8 @@ rm /tmp/consul-template.zip
 VAULT_VERSION=1.5.4
 wget -q -O /tmp/vault.zip "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip"
 unzip -d /tmp /tmp/vault.zip
-sudo mv /tmp/vault /usr/bin/vault
-sudo chmod +x /usr/bin/vault
+mv /tmp/vault /usr/local/bin/vault
+chmod +x /usr/local/bin/vault
 rm -rf /tmp/vault*
 
 # Install consul-bootstrap

--- a/spec/Dockerfile_spec.rb
+++ b/spec/Dockerfile_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-distros = ["debian", "centos", "alpine"]
+distros = ["debian", "centos", "amazon-linux", "alpine"]
 
 distros.each do |distro|
   describe "Dockerfile" do

--- a/spec/dockerfiles/Dockerfile.amazon-linux.erb
+++ b/spec/dockerfiles/Dockerfile.amazon-linux.erb
@@ -1,0 +1,14 @@
+FROM lambci/lambda:build-nodejs12.x
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/<%= @git_commit %>/install.sh /tmp/consul_template_install.sh
+RUN bash -e /tmp/consul_template_install.sh <%= @git_commit %> && rm /tmp/consul_template_install.sh
+
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD "/bin/sh"


### PR DESCRIPTION
These images are interesting in that they don't have sudo on them.
Fortunately, none of the things we're using sudo for actually require it.

In other good news, these lambda images allow us to install jq from the amazon repository
rather than needing to use EPEL.

This also updates the vault binary location to match the other binaries being
installed.

Also adds tests for the amazon linux lambda nodejs image.