### PR TITLE
Display the vault error on failure to get a token

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,13 +41,15 @@ if [ ${VAULT_ADDR} ]
     vault_token="null"
     attempts=1
     while [ "${attempts}" -le 10 ]; do
-      vault_token=$(curl -s --show-error --request POST \
+      response=$(curl -s --show-error --request POST \
         --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "'"$SERVICE_NAME"'"}' \
-        $VAULT_ADDR/v1/auth/kubernetes/login | jq -r '.auth.client_token');
+        $VAULT_ADDR/v1/auth/kubernetes/login)
+      vault_token=$(echo $response | jq -r '.auth.client_token');
       if [[ "${vault_token}" != "null" ]]; then
         break
       fi
       echo "Attempt number ${attempts} to get vault token failed, retrying..."
+      echo "Vault response: $(echo $response | jq '.errors[]')"
       ((attempts+=1))
       sleep 3
     done

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # Due to docker's layer caching, you may need to update this file in a way to force docker
 # to skip the layer cache and re-run this install the next time it builds the image.
-# Simply edit the date here: 2020-10-26
+# Simply edit the date here: 2020-11-12
 
 CONSUL_TEMPLATE_BOOTSTRAP_REF=$1
 if [ "${CONSUL_TEMPLATE_BOOTSTRAP_REF}" == "" ]; then


### PR DESCRIPTION
When vault fails to get a token, it's not clear why.  Let's print the error message vault sent back if there's an error.