### PR TITLE
Make consul only be overrides in prod

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # Due to docker's layer caching, you may need to update this file in a way to force docker
 # to skip the layer cache and re-run this install the next time it builds the image.
-# Simply edit the date here: 2020-11-12
+# Simply edit the date here: 2021-04-12.1
 
 CONSUL_TEMPLATE_BOOTSTRAP_REF=$1
 if [ "${CONSUL_TEMPLATE_BOOTSTRAP_REF}" == "" ]; then

--- a/prod/export-consul.ctmpl
+++ b/prod/export-consul.ctmpl
@@ -2,27 +2,37 @@
 
 ## OLD STYLE global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}
+{{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}
 
 ## NEW STYLE global envs
 {{range ls "global/env_vars" -}}
+{{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}
 
 #products envs
 {{if (env "SERVICE_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
+{{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}
 {{end -}}
 
 #OLD STYLE app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
+{{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}
 
 #NEW STYLE app envs
 {{range ls (printf "services/%s/env_vars" (env "SERVICE_NAME")) -}}
+{{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
+{{end -}}
 {{end -}}

--- a/prod/export-vault.ctmpl
+++ b/prod/export-vault.ctmpl
@@ -2,27 +2,37 @@
 
 ## OLD DEPRECATED STYLE global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}
+{{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
 {{end -}}
 
 #NEW STYLE global secrets
 {{range secrets "secret/global/env_vars" -}}
+{{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
+{{end -}}
 {{end -}}
 
 #products secrets
 {{if (env "SERVICE_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
+{{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (env "SERVICE_PRODUCT") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
 {{end -}}
 {{end -}}
 
 #OLD DEPRECATED STYLE app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
+{{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
 {{end -}}
 
 #NEW STYLE app secrets
 {{range secrets (printf "secret/services/%s/env_vars" (env "SERVICE_NAME")) -}}
+{{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}
+{{end -}}
 {{end -}}


### PR DESCRIPTION
https://github.com/articulate/docker-consul-template-bootstrap/pull/53 was originally done for staging,
but was never rolled out to prod.  This has led to occasional different behaviour with staging and prod
on the odd occasion that an env var was set both on the container and in consul to different values.