### PR TITLE
Install AWS CLI v2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ fi
 # Install awscli
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip
-sudo ./aws/install
+./aws/install
 rm -r awscliv2.zip aws
 
 # Install Consul template


### PR DESCRIPTION
This PR removes the dependency of Python 2.7 by upgrading to AWS CLI v2.