### PR TITLE
improve install script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
 
 jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: shellcheck install.sh
   dockerspec:
     runs-on: ubuntu-latest
     steps:

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# Due to docker's layer caching, you may need to update this file in a way to force docker
-# to skip the layer cache and re-run this install the next time it builds the image.
-# Simply edit the date here: 2021-06-11.1
-
 CONSUL_TEMPLATE_BOOTSTRAP_REF="${1:-master}"
 
 if command -v apt-get; then
@@ -23,6 +19,7 @@ elif command -v yum; then
   yum -y update
   yum -y install unzip jq sudo wget curl which
   yum clean all
+  rm -rf /var/cache/yum
 
   # AWS CLI
   curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
@@ -41,26 +38,28 @@ else
   exit 1
 fi
 
+arch="linux_amd64"
+[ "$(uname -m)" == "aarch64" ] && arch="linux_arm64"
+
 # Install Consul template
-CONSUL_TEMPLATE_VERSION=0.25.1
-wget -q -O /tmp/consul-template.zip "https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip"
-unzip -d /usr/local/bin /tmp/consul-template.zip
+CONSUL_TEMPLATE_VERSION="${CONSUL_TEMPLATE_VERSION:-0.28.1}"
+curl -s "https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_${arch}.zip" -o /tmp/consul-template.zip
+unzip /tmp/consul-template.zip consul-template -d /usr/local/bin
 rm /tmp/consul-template.zip
 
 # Install Vault CLI
-VAULT_VERSION=1.5.4
-wget -q -O /tmp/vault.zip "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip"
-unzip -d /tmp /tmp/vault.zip
-mv /tmp/vault /usr/local/bin/vault
-chmod +x /usr/local/bin/vault
-rm -rf /tmp/vault*
+VAULT_VERSION="${VAULT_VERSION:-1.10.0}"
+curl -s "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${arch}.zip" -o /tmp/vault.zip
+unzip /tmp/vault.zip vault -d /usr/local/bin
+rm /tmp/vault.zip
 
 # Install consul-bootstrap
-wget -q -O /tmp/docker-consul-template-bootstrap.zip "https://github.com/articulate/docker-consul-template-bootstrap/archive/${CONSUL_TEMPLATE_BOOTSTRAP_REF}.zip"
-unzip -d /tmp /tmp/docker-consul-template-bootstrap.zip
-mv "/tmp/docker-consul-template-bootstrap-${CONSUL_TEMPLATE_BOOTSTRAP_REF}/" /consul-template/
-mv /consul-template/entrypoint.sh /entrypoint.sh
-rm /tmp/docker-consul-template-bootstrap.zip
+curl -Ls "https://github.com/articulate/docker-consul-template-bootstrap/archive/${CONSUL_TEMPLATE_BOOTSTRAP_REF}.zip" -o /tmp/docker-consul-template-bootstrap.zip
+unzip /tmp/docker-consul-template-bootstrap.zip -d /tmp
+mkdir -p /consul-template/
+mv "/tmp/docker-consul-template-bootstrap-${CONSUL_TEMPLATE_BOOTSTRAP_REF}"/{apiary,dev,peer,prod,stage} /consul-template/
+mv "/tmp/docker-consul-template-bootstrap-${CONSUL_TEMPLATE_BOOTSTRAP_REF}/entrypoint.sh" /entrypoint.sh
+rm -rf /tmp/docker-consul-template-bootstrap*
 
 for package in wget jq curl which aws consul-template vault; do
   if ! command -v "$package"; then

--- a/install.sh
+++ b/install.sh
@@ -8,24 +8,12 @@ if command -v apt-get; then
   apt-get -y install --no-install-recommends unzip sudo jq wget curl ca-certificates
   apt-get clean && apt-get autoclean && apt-get -y autoremove --purge
   rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/
-
-  # AWS CLI
-  curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
-  unzip -d /tmp /tmp/awscliv2.zip
-  /tmp/aws/install
-  rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip
 elif command -v yum; then
   grep "Amazon Linux" /etc/os-release &>/dev/null || yum -y install epel-release
   yum -y update
   yum -y install unzip jq sudo wget curl which
   yum clean all
   rm -rf /var/cache/yum
-
-  # AWS CLI
-  curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
-  unzip -d /tmp /tmp/awscliv2.zip
-  /tmp/aws/install
-  rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip
 elif command -v apk; then
   apk add --no-cache --update unzip sudo python3 jq wget ca-certificates curl which py3-pip
   update-ca-certificates
@@ -33,9 +21,17 @@ elif command -v apk; then
 
   # Use the Python version of AWS CLI since they don't provide a musl compatible build
   pip3 --no-cache-dir install awscli
+  SKIP_AWS_INSTALL=1
 else
   echo "Existing package manager is not supported"
   exit 1
+fi
+
+if [ -z "$SKIP_AWS_INSTALL" ]; then
+  curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+  unzip -d /tmp /tmp/awscliv2.zip
+  /tmp/aws/install
+  rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip
 fi
 
 arch="linux_amd64"


### PR DESCRIPTION
* Install the correct architecture binaries for consul-template and vault.
* Install the latest versions of those as of this PR.
* Use curl for any downloads so we don't need both curl and wget installed. (kept wget for now since other images are probably relying on it)
* Only install needed files from the bootstrap
* Make sure we are cleaning up bootstrap files we don't use
* Improve yum cleanup