### PR TITLE
Cleanup entrypoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: shellcheck install.sh
+      - run: shellcheck install.sh entrypoint.sh
   dockerspec:
     runs-on: ubuntu-latest
     steps:

--- a/dev/export-consul.ctmpl
+++ b/dev/export-consul.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD STYLE global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/dev/export-consul.ctmpl
+++ b/dev/export-consul.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD STYLE global envs
+# DEPRECATED: global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-## NEW STYLE global envs
+# global envs
 {{range ls "global/env_vars" -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#products envs
+# DEPRECATED: products envs
 {{if (env "SERVICE_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (.Key | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#OLD STYLE app envs
+# DEPRECATED: app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#NEW STYLE app envs
+# service envs
 {{range ls (printf "services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"

--- a/dev/export-vault.ctmpl
+++ b/dev/export-vault.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD DEPRECATED STYLE global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/dev/export-vault.ctmpl
+++ b/dev/export-vault.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD DEPRECATED STYLE global secrets
+# DEPRECATED: global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#products secrets
+# DEPRECATED: products secrets
 {{if (env "SERVICE_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/dev/env_vars" (env "SERVICE_PRODUCT")) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/products/%s/dev/env_vars/%s" (env "SERVICE_PRODUCT") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#OLD DEPRECATED STYLE app secrets
+# DEPRECATED: app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,93 +1,74 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 AWS_REGION="${AWS_REGION:-us-east-1}"
-if [ "${APP_ENV}" != "" ]; then
-  (>&2 echo "Using deprecated APP_ENV, please swap to SERVICE_ENV")
-  export SERVICE_ENV="${APP_ENV}"
-fi
-if [ "${APP_NAME}" != "" ]; then
-  (>&2 echo "Using deprecated APP_NAME, please swap to SERVICE_NAME")
-  export SERVICE_NAME="${APP_NAME}"
-fi
-if [ "${APP_PRODUCT}" != "" ]; then
-  (>&2 echo "Using deprecated APP_PRODUCT, please swap to SERVICE_PRODUCT")
-  export SERVICE_PRODUCT="${APP_PRODUCT}"
-fi
 
 # This will return everything before a - chararacter.
 # "peer-something-thing" => "peer"
 CT_SERVICE_ENV="${SERVICE_ENV%%-*}"
 
-MISBEHAVING_NOTICE="may be misbehaving. In a perfect world, our monitoring detected this problem and Platform Engineering was alerted... but just in case, please let us know."
-
-if [ ${CONSUL_ADDR} ]
-then
-  if consul-template -consul-addr=$CONSUL_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-consul.ctmpl:/tmp/export-consul.sh -once -max-stale=0
-  then
+if [ -n "$CONSUL_ADDR" ]; then
+  if consul-template -consul-addr="$CONSUL_ADDR" -template="/consul-template/${CT_SERVICE_ENV}/export-consul.ctmpl:/tmp/export-consul.sh" -once -max-stale=0; then
+    # shellcheck disable=SC1091
     source /tmp/export-consul.sh
+    rm -f /tmp/export-consul.sh
   else
-    (>&2 echo "Consul $MISBEHAVING_NOTICE")
+    (>&2 echo "ERROR: Unable to export from Consul")
     exit 1
   fi
 else
-  (>&2 echo "CONSUL_ADDR are not set skipping Consul exports")
+  (>&2 echo "WARN: CONSUL_ADDR is not set, skipping Consul exports")
 fi
 
-if [ ${VAULT_ADDR} ]
-  then
-  if [ ! "${VAULT_TOKEN}" ] && [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]
-  then
+if [ -n "$VAULT_ADDR" ]; then
+  if [ -z "$VAULT_TOKEN" ] && [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
     KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-    vault_token="null"
+    VAULT_TOKEN="null"
     attempts=1
     while [ "${attempts}" -le 10 ]; do
       response=$(curl -s --show-error --request POST \
         --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "'"$SERVICE_NAME"'"}' \
-        $VAULT_ADDR/v1/auth/kubernetes/login)
-      vault_token=$(echo $response | jq -r '.auth.client_token');
-      if [[ "${vault_token}" != "null" ]]; then
-        break
-      fi
-      echo "Attempt number ${attempts} to get vault token failed, retrying..."
-      echo "Vault response: $(echo $response | jq '.errors[]')"
+        "${VAULT_ADDR}/v1/auth/kubernetes/login")
+      VAULT_TOKEN=$(echo "$response" | jq -r '.auth.client_token')
+      [[ "$VAULT_TOKEN" != "null" ]] && break
+      (>&2 echo "Attempt number ${attempts} to get vault token failed, retrying...")
+      (>&2 echo "Vault response: $(echo "$response" | jq '.errors[]')")
       ((attempts+=1))
       sleep 3
     done
 
-    if [[ "${vault_token}" == "null" ]]; then
+    if [[ "$VAULT_TOKEN" == "null" ]]; then
       echo "Failed to get vault token via kubernetes"
       exit 1
     fi
-    export VAULT_TOKEN=${vault_token}
+
+    export VAULT_TOKEN
   fi
 
-  if [ "${ENCRYPTED_VAULT_TOKEN}" ] && [ ! "${VAULT_TOKEN}" ]
-  then
-    export VAULT_TOKEN=$(echo $ENCRYPTED_VAULT_TOKEN | base64 -d | aws kms decrypt --ciphertext-blob fileb:///dev/stdin --output text --query Plaintext --region $AWS_REGION | base64 -d)
+  if [ -n "$ENCRYPTED_VAULT_TOKEN" ] && [ -z "$VAULT_TOKEN" ]; then
+    VAULT_TOKEN=$(echo "$ENCRYPTED_VAULT_TOKEN" | base64 -d | aws kms decrypt --ciphertext-blob fileb:///dev/stdin --output text --query Plaintext --region "$AWS_REGION" | base64 -d)
+    export VAULT_TOKEN
   fi
 
-  if [ ! "${VAULT_TOKEN}" ] && [ "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" ]
-  then
-    export VAULT_TOKEN=$(vault login -method=aws -token-only)
+  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
+    VAULT_TOKEN=$(vault login -method=aws -token-only)
+    export VAULT_TOKEN
   fi
 
-  if [ ${VAULT_TOKEN} ] && [ ${CONSUL_ADDR} ]
-  then
-    if consul-template -consul-addr=$CONSUL_ADDR -vault-addr=$VAULT_ADDR -template=/consul-template/${CT_SERVICE_ENV}/export-vault.ctmpl:/tmp/export-vault.sh -once -max-stale=0
-    then
+  if [ -n "$VAULT_TOKEN" ] && [ -n "$CONSUL_ADDR" ]; then
+    if consul-template -consul-addr="$CONSUL_ADDR" -vault-addr="$VAULT_ADDR" -template="/consul-template/${CT_SERVICE_ENV}/export-vault.ctmpl:/tmp/export-vault.sh" -once -max-stale=0; then
+      # shellcheck disable=SC1091
       source /tmp/export-vault.sh
+      rm -f /tmp/export-vault.sh
     else
-      (>&2 echo "Vault $MISBEHAVING_NOTICE")
+      (>&2 echo "ERROR: Unable to export from Vault")
       exit 1
     fi
   else
-    (>&2 echo "VAULT_TOKEN and/or CONSUL_ADDR not set, skipping Vault exports")
+    (>&2 echo "WARN: VAULT_TOKEN and/or CONSUL_ADDR not set, skipping Vault exports")
   fi
 else
-    (>&2 echo "VAULT_ADDR is not set, skipping Vault exports")
+  (>&2 echo "WARN: VAULT_ADDR is not set, skipping Vault exports")
 fi
-
-rm -f /tmp/export-vault.sh
-rm -f /tmp/export-consul.sh
 
 exec "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 CONSUL_TEMPLATE_BOOTSTRAP_REF="${1:-master}"
@@ -15,7 +15,7 @@ elif command -v yum; then
   yum clean all
   rm -rf /var/cache/yum
 elif command -v apk; then
-  apk add --no-cache --update unzip sudo python3 jq wget ca-certificates curl which py3-pip
+  apk add --no-cache --update unzip sudo python3 jq wget ca-certificates curl which py3-pip bash
   update-ca-certificates
   rm -rf /var/cache/apk/*
 
@@ -23,7 +23,7 @@ elif command -v apk; then
   pip3 --no-cache-dir install awscli
   SKIP_AWS_INSTALL=1
 else
-  echo "Existing package manager is not supported"
+  echo "Could not find a supported package manager (apt-get, yum, apk)."
   exit 1
 fi
 

--- a/peer/export-consul.ctmpl
+++ b/peer/export-consul.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD STYLE global envs
+# DEPRECATED: global envs
 {{range ls "global/stage/env_vars" -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-## NEW STYLE global envs
+# global envs
 {{range ls "global/env_vars" -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#products envs
+# DEPRECATED: products envs
 {{if (env "SERVICE_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (.Key | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#OLD STYLE app envs
+# DEPRECATED: app envs
 {{range ls (printf "apps/%s/stage/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#NEW STYLE app envs
+# service envs
 {{range ls (printf "services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"

--- a/peer/export-consul.ctmpl
+++ b/peer/export-consul.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD STYLE global envs
 {{range ls "global/stage/env_vars" -}}

--- a/peer/export-vault.ctmpl
+++ b/peer/export-vault.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD DEPRECATED STYLE global secrets
+# DEPRECATED: global secrets
 {{range secrets "secret/global/stage/env_vars" -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/stage/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE global secrets
+# global secrets
 {{range secrets "secret/global/env_vars" -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#products secrets
+# DEPRECATED: products secrets
 {{if (env "SERVICE_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (. | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 {{end -}}
 
-#OLD DEPRECATED STYLE app secrets
+# DEPRECATED: app secrets
 {{range secrets (printf "secret/apps/%s/stage/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/stage/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE app secrets
+# service secrets
 {{range secrets (printf "secret/services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}

--- a/peer/export-vault.ctmpl
+++ b/peer/export-vault.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD DEPRECATED STYLE global secrets
 {{range secrets "secret/global/stage/env_vars" -}}

--- a/prod/export-consul.ctmpl
+++ b/prod/export-consul.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD STYLE global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/prod/export-consul.ctmpl
+++ b/prod/export-consul.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD STYLE global envs
+# DEPRECATED: global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-## NEW STYLE global envs
+# global envs
 {{range ls "global/env_vars" -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#products envs
+# DEPRECATED: products envs
 {{if (env "SERVICE_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (.Key | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#OLD STYLE app envs
+# DEPRECATED: app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#NEW STYLE app envs
+# service envs
 {{range ls (printf "services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"

--- a/prod/export-vault.ctmpl
+++ b/prod/export-vault.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD DEPRECATED STYLE global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/prod/export-vault.ctmpl
+++ b/prod/export-vault.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD DEPRECATED STYLE global secrets
+# DEPRECATED: global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE global secrets
+# global secrets
 {{range secrets "secret/global/env_vars" -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#products secrets
+# DEPRECATED: products secrets
 {{if (env "SERVICE_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (. | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 {{end -}}
 
-#OLD DEPRECATED STYLE app secrets
+# DEPRECATED: app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE app secrets
+# service secrets
 {{range secrets (printf "secret/services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}

--- a/stage/export-consul.ctmpl
+++ b/stage/export-consul.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD STYLE global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/stage/export-consul.ctmpl
+++ b/stage/export-consul.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD STYLE global envs
+# DEPRECATED: global envs
 {{range ls (printf "global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-## NEW STYLE global envs
+# global envs
 {{range ls "global/env_vars" -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#products envs
+# DEPRECATED: products envs
 {{if (env "SERVICE_PRODUCT") -}}
 {{range ls (printf "products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (.Key | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#OLD STYLE app envs
+# DEPRECATED: app envs
 {{range ls (printf "apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"
 {{end -}}
 {{end -}}
 
-#NEW STYLE app envs
+# service envs
 {{range ls (printf "services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (.Key | toUpper)) -}}
 export {{.Key | toUpper}}="{{.Value}}"

--- a/stage/export-vault.ctmpl
+++ b/stage/export-vault.ctmpl
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 ## OLD DEPRECATED STYLE global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}

--- a/stage/export-vault.ctmpl
+++ b/stage/export-vault.ctmpl
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-## OLD DEPRECATED STYLE global secrets
+# DEPRECATED: global secrets
 {{range secrets (printf "secret/global/%s/env_vars" (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/%s/env_vars/%s" (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE global secrets
+# global secrets
 {{range secrets "secret/global/env_vars" -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/global/env_vars/%s" .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#products secrets
+# DEPRECATED: products secrets
 {{if (env "SERVICE_PRODUCT") -}}
 {{range secrets (printf "secret/products/%s/env_vars" (env "SERVICE_PRODUCT")) -}}
 {{if not (env (. | toUpper)) -}}
@@ -24,14 +24,14 @@ export {{ . | toUpper}}{{with secret (printf "secret/products/%s/env_vars/%s" (e
 {{end -}}
 {{end -}}
 
-#OLD DEPRECATED STYLE app secrets
+# DEPRECATED: app secrets
 {{range secrets (printf "secret/apps/%s/%s/env_vars" (env "SERVICE_NAME") (env "SERVICE_ENV")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/apps/%s/%s/env_vars/%s" (env "SERVICE_NAME") (env "SERVICE_ENV") .) }}="{{.Data.value}}"{{end}}
 {{end -}}
 {{end -}}
 
-#NEW STYLE app secrets
+# service secrets
 {{range secrets (printf "secret/services/%s/env_vars" (env "SERVICE_NAME")) -}}
 {{if not (env (. | toUpper)) -}}
 export {{ . | toUpper}}{{with secret (printf "secret/services/%s/env_vars/%s" (env "SERVICE_NAME") .) }}="{{.Data.value}}"{{end}}


### PR DESCRIPTION
Make sure our entrypoint is following best practices and passes shellcheck. Improve logging, making sure everything goes to STDERR is is prefixed with a level.

Make sure we're using bash everywhere and we're allowing the system to select which bash to use if it's in a non-standard location. Installs bash on Alpine, since it doesn't ship with it by default and we use bash specific syntax in the entrypoint.

Clearly document which paths are deprecated, including products, which is newly deprecated