### PR TITLE
feat(entrypoint): allow authenticating vault with a role

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,8 +50,10 @@ if [ -n "$VAULT_ADDR" ]; then
     export VAULT_TOKEN
   fi
 
-  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
-    VAULT_TOKEN=$(vault login -method=aws -token-only)
+  # shellcheck disable=SC2166
+  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" -o -n "$AWS_LAMBDA_FUNCTION_NAME" ]; then
+    [ -n "$VAULT_ROLE" ] && role="role=${VAULT_ROLE}"
+    VAULT_TOKEN=$(vault login -method=aws -token-only "$role")
     export VAULT_TOKEN
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ if [ -n "$VAULT_ADDR" ]; then
     done
 
     if [[ "$VAULT_TOKEN" == "null" ]]; then
-      echo "Failed to get vault token via kubernetes"
+      (>&2 echo "ERROR: Unable to get vault token via kubernetes")
       exit 1
     fi
 


### PR DESCRIPTION
Adds support for a VAULT_AUTH_ROLE environment variable which will authenticate with a VAULT_AUTH_PROVIDER (default aws) to allow for more generic authentication methods.