### PR TITLE
allow loading of additional paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,12 @@ func loadConsul(addr string, c Config, l zerolog.Logger) Dict {
 		l.Fatal().Err(err).Str("addr", addr).Msg("Could not connect to Consul")
 	}
 
-	return loadValues(client, l, c.ConsulPaths())
+	paths := c.ConsulPaths()
+	if p := os.Getenv("CONSUL_PATHS"); p != "" {
+		paths = append(paths, strings.Split(p, ",")...)
+	}
+
+	return loadValues(client, l, paths)
 }
 
 func loadVault(ctx context.Context, addr string, c Config, l zerolog.Logger) Dict {
@@ -87,7 +92,12 @@ func loadVault(ctx context.Context, addr string, c Config, l zerolog.Logger) Dic
 		l.Fatal().Err(err).Msg("Could not authenticate Vault")
 	}
 
-	values := loadValues(client, l, c.VaultPaths())
+	paths := c.VaultPaths()
+	if p := os.Getenv("VAULT_PATHS"); p != "" {
+		paths = append(paths, strings.Split(p, ",")...)
+	}
+
+	values := loadValues(client, l, paths)
 	values["VAULT_TOKEN"] = auth
 	return values
 }


### PR DESCRIPTION
There have been a few cases where it would be nice to load additional paths, such as sharing env vars between a set of common applications. Adds the ability to set CONSUL_PATH and VAULT_PATH to load these additional paths (seperated by comma) after the default paths