### PR TITLE
Simplify conditional statement

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,8 +50,13 @@ if [ -n "$VAULT_ADDR" ]; then
     export VAULT_TOKEN
   fi
 
-  # shellcheck disable=SC2166
-  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" -o -n "$AWS_LAMBDA_FUNCTION_NAME" ]; then
+  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" ]; then
+    [ -n "$VAULT_ROLE" ] && role="role=${VAULT_ROLE}"
+    VAULT_TOKEN=$(vault login -method=aws -token-only "$role")
+    export VAULT_TOKEN
+  fi
+
+  if [ -z "$VAULT_TOKEN" ] && [ -n "$AWS_LAMBDA_FUNCTION_NAME" ]; then
     [ -n "$VAULT_ROLE" ] && role="role=${VAULT_ROLE}"
     VAULT_TOKEN=$(vault login -method=aws -token-only "$role")
     export VAULT_TOKEN

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # NOTE: Update if changes are made to this repo that need to be included in the images
-# CACHE VERSION: 202209121400
+# CACHE VERSION: 20221114
 
 set -eo pipefail
 


### PR DESCRIPTION
There's a lot of debate about where or not `-o` as an `||` operative actually works.

I'm currently encountering an issue (documented in Slack [here](https://articulate.slack.com/archives/C01BSR9859A/p1668137365151549?thread_ts=1668028855.721709&cid=C01BSR9859A)) where this section of code isn't triggering, even when there is no VAULT_TOKEN, there is a AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, and there is a VAULT_ROLE. I think it's because this messy `-o` logic isn't working. 

Splitting it in to two conditionals has the same outcome, it's just annoying duplicate code. 