### PR TITLE
fix(consul): don't parse address

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -14,15 +13,10 @@ type Consul struct {
 
 // NewConsul returns a new instance of the Consul client using the given address
 func NewConsul(addr string) (*Consul, error) {
-	a, err := url.Parse(addr)
-	if err != nil {
-		return nil, err
-	}
+	cfg := api.DefaultConfig()
+	cfg.Address = addr
 
-	c, err := api.NewClient(&api.Config{
-		Address: a.Host,
-		Scheme:  a.Scheme,
-	})
+	c, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/consul_test.go
+++ b/consul_test.go
@@ -6,12 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewConsul(t *testing.T) {
-	c, err := NewConsul("foo:b\ar;baz")
-	assert.Nil(t, c)
-	assert.ErrorContains(t, err, "parse")
-}
-
 func TestConsulKey(t *testing.T) {
 	assert.Equal(t, consulKey("foo/bar/baz"), "BAZ")
 	assert.Equal(t, consulKey("test"), "TEST")


### PR DESCRIPTION
Using the DefaultConfig from consul and set the Address value, which Consul will then take care of parsing