### PR TITLE
fix(vault): only authenticate vault in known AWS environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,11 @@ func loadVault(ctx context.Context, addr string, c Config, l zerolog.Logger) Dic
 		l.Fatal().Err(err).Msg("Could not authenticate Vault")
 	}
 
+	if auth == "" {
+		l.Warn().Msg("Not loading values from Vault. Unable to authenticate Vault")
+		return make(Dict)
+	}
+
 	paths := c.VaultPaths()
 	if p := os.Getenv("VAULT_PATHS"); p != "" {
 		paths = append(paths, strings.Split(p, ",")...)

--- a/vault.go
+++ b/vault.go
@@ -40,7 +40,7 @@ func (v *Vault) Authenticate(ctx context.Context, token, role string) (string, e
 	}
 
 	auth, err := v.getAuthMethod(role)
-	if err != nil {
+	if auth == nil || err != nil {
 		return "", err
 	}
 
@@ -56,6 +56,13 @@ func (v *Vault) Authenticate(ctx context.Context, token, role string) (string, e
 func (v *Vault) getAuthMethod(role string) (api.AuthMethod, error) {
 	if _, err := os.Stat(k8sTokenFile); !os.IsNotExist(err) {
 		return kubernetes.NewKubernetesAuth(role)
+	}
+
+	ecs := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	lambda := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+
+	if ecs == "" && lambda == "" {
+		return nil, nil
 	}
 
 	region := os.Getenv("AWS_REGION")


### PR DESCRIPTION
When running tests on Docker images, we won't be able to authenticate with Vault. Only authenticate Vault on known environments (ECS/Beanstalk and Lambda)