### PR TITLE
Fix dev namespace for global and product lookups

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,8 +32,8 @@ func (c *Config) VaultPaths() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("secret/global/%s/%s/env_vars", c.Environment, c.Environment), // DEPRECATED
-		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment),   // DEPRECATED
-		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment),       // DEPRECATED
+		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),                 // DEPRECATED
+		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment), // DEPRECATED
+		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment),     // DEPRECATED
 	}
 }

--- a/config.go
+++ b/config.go
@@ -32,8 +32,8 @@ func (c *Config) VaultPaths() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),             // DEPRECATED
-		fmt.Sprintf("secret/products/%s/env_vars", c.Product),               // DEPRECATED
+		fmt.Sprintf("secret/global/%s/%s/env_vars", c.Environment, c.Environment),             // DEPRECATED
+		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment),               // DEPRECATED
 		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
 	}
 }

--- a/config.go
+++ b/config.go
@@ -32,8 +32,8 @@ func (c *Config) VaultPaths() []string {
 	}
 
 	return []string{
-		fmt.Sprintf("secret/global/%s/%s/env_vars", c.Environment, c.Environment),             // DEPRECATED
-		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment),               // DEPRECATED
-		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
+		fmt.Sprintf("secret/global/%s/%s/env_vars", c.Environment, c.Environment), // DEPRECATED
+		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment),   // DEPRECATED
+		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment),       // DEPRECATED
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -49,7 +49,7 @@ func TestConfig_VaultPaths(t *testing.T) {
 	c.Environment = "dev"
 	assert.Equal(t, []string{
 		"secret/global/dev/env_vars",
-		"secret/products/bar/env_vars",
+		"secret/products/bar/dev/env_vars",
 		"secret/apps/foo/dev/env_vars",
 	}, c.VaultPaths())
 }


### PR DESCRIPTION
When this was coverted to go, we accidentally made it load all secrets from global and products, but we originally intended it so that we never load secrets from stage into local dev due to the possibility of breaking stage.

Instead we only load secrets from a `dev` namespace to ensure that they don't collide.

See original code here: https://github.com/articulate/docker-consul-template-bootstrap/blob/11f43c1ad920a517b071d8d6ffc85876682065b5/dev/export-vault.ctmpl#L15-L29