### PR TITLE
fix(consul): skip empty consul keys

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -34,6 +34,9 @@ func (c *Consul) Load(path string) (Dict, error) {
 	}
 
 	for _, p := range pairs {
+		if p.Value == nil {
+			continue
+		}
 		kv[consulKey(p.Key)] = string(p.Value)
 	}
 


### PR DESCRIPTION
Sometimes it was picking up the top level as a keypair and causing an empty key to be inserted into the environment. Check the keypair has a value before adding it to the environment