### PR TITLE
chore(scripts): add script to install awscli on Debian

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,9 @@ jobs:
           check-latest: true
           cache: true
       - run: make test
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: shellcheck scripts/*

--- a/scripts/awscli.sh
+++ b/scripts/awscli.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+AWSCLI_VERSION="${AWSCLI_VERSION:-2.9.15}"
+
+missing=""
+command -v curl >/dev/null || missing="${missing} curl"
+command -v unzip >/dev/null || missing="${missing} unzip"
+test -d /etc/ssl/certs || missing="${missing} ca-certificates"
+
+if [ "$missing" != "" ]; then
+    apt-get update -qq
+    # shellcheck disable=SC2086
+    apt-get install --yes --no-install-recommends $missing
+fi
+
+curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip
+unzip -q -d /tmp /tmp/awscliv2.zip
+/tmp/aws/install
+rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip
+
+if [ "$missing" != "" ]; then
+    # shellcheck disable=SC2086
+    apt-get remove --yes $missing
+    apt-get clean
+    apt-get autoclean
+    apt-get autoremove --yes --purge
+    rm -rf /var/lib/apt/lists/* /usr/share/doc /root/.cache/
+fi


### PR DESCRIPTION
Adds a script to install awscli@v2 while keeping the smallest layer size. Any tools it needs to install are then removed, but only if this script installed them