### PR TITLE
fix(docker-secrets): allow secrets to run when there are no secrets

### DIFF
--- a/scripts/docker-secrets
+++ b/scripts/docker-secrets
@@ -2,11 +2,13 @@
 # Load Docker secrets as environment variables
 #
 # Usage:
-#   . /opt/secrets - Load environment variables into shell
-#   /opt/secrets [command] - Run a command with environment variables
+#   . $0 - Load environment variables into shell
+#   $0 [command] - Run a command with environment variables
 
-for secret in /run/secrets/*; do
-    export "$(basename "$secret")=$(cat "$secret")"
-done
+if [ -d /run/secrets ]; then
+    for secret in /run/secrets/*; do
+        export "$(basename "$secret")=$(cat "$secret")"
+    done
+fi
 
 exec "$@"


### PR DESCRIPTION
If secrets do not exist, this will fail saying it cannot export *. Check for the directory first before trying to load secrets