### PR TITLE
feat: load service env paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can authenticate with Vault in one of the following ways:
 
 You'll need to install the following:
 
-* Go 1.19
+* Go 1.20
 * [golangci-lint](https://golangci-lint.run/) (`brew install golangci-lint`)
 * [pre-commit](https://pre-commit.com/) (`brew install pre-commit`)
 * [GoReleaser](https://goreleaser.com/) (_optional_)

--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Config struct {
 	Service     string
@@ -12,11 +14,12 @@ type Config struct {
 // ConsulPaths returns the paths from Consul to load
 func (c *Config) ConsulPaths() []string {
 	return []string{
-		fmt.Sprintf("global/%s/env_vars", c.Environment), // DEPRECATED
 		"global/env_vars",
+		fmt.Sprintf("global/%s/env_vars", c.Environment),
 		fmt.Sprintf("products/%s/env_vars", c.Product),               // DEPRECATED
 		fmt.Sprintf("apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
 		fmt.Sprintf("services/%s/env_vars", c.Service),
+		fmt.Sprintf("services/%s/%s/env_vars", c.Service, c.Environment),
 	}
 }
 
@@ -24,17 +27,19 @@ func (c *Config) ConsulPaths() []string {
 func (c *Config) VaultPaths() []string {
 	if c.Environment == "stage" || c.Environment == "prod" {
 		return []string{
-			fmt.Sprintf("secret/global/%s/env_vars", c.Environment), // DEPRECATED
 			"secret/global/env_vars",
+			fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
 			fmt.Sprintf("secret/products/%s/env_vars", c.Product),               // DEPRECATED
 			fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
 			fmt.Sprintf("secret/services/%s/env_vars", c.Service),
+			fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
 		}
 	}
 
 	return []string{
-		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),                 // DEPRECATED
+		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
 		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment), // DEPRECATED
 		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment),     // DEPRECATED
+		fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -14,11 +14,12 @@ func TestConfig_ConsulPaths(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{
-		"global/stage/env_vars",
 		"global/env_vars",
+		"global/stage/env_vars",
 		"products/bar/env_vars",
 		"apps/foo/stage/env_vars",
 		"services/foo/env_vars",
+		"services/foo/stage/env_vars",
 	}, c.ConsulPaths())
 }
 
@@ -30,20 +31,22 @@ func TestConfig_VaultPaths(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{
-		"secret/global/stage/env_vars",
 		"secret/global/env_vars",
+		"secret/global/stage/env_vars",
 		"secret/products/bar/env_vars",
 		"secret/apps/foo/stage/env_vars",
 		"secret/services/foo/env_vars",
+		"secret/services/foo/stage/env_vars",
 	}, c.VaultPaths())
 
 	c.Environment = "prod"
 	assert.Equal(t, []string{
-		"secret/global/prod/env_vars",
 		"secret/global/env_vars",
+		"secret/global/prod/env_vars",
 		"secret/products/bar/env_vars",
 		"secret/apps/foo/prod/env_vars",
 		"secret/services/foo/env_vars",
+		"secret/services/foo/prod/env_vars",
 	}, c.VaultPaths())
 
 	c.Environment = "dev"
@@ -51,5 +54,6 @@ func TestConfig_VaultPaths(t *testing.T) {
 		"secret/global/dev/env_vars",
 		"secret/products/bar/dev/env_vars",
 		"secret/apps/foo/dev/env_vars",
+		"secret/services/foo/dev/env_vars",
 	}, c.VaultPaths())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/articulate/docker-consul-template-bootstrap
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.21


### PR DESCRIPTION
Loads `service/{service}/{env}/env_var` path.

Change load order for env specific paths to take precedence.

Update to Go 1.20